### PR TITLE
use $JOBS to parallelise make

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,7 +32,7 @@ module.exports = function (args, moduleDir, debug) {
 		if (process.env.JOBS) {
 			makeopts.push("-j" + process.env.JOBS);
 		}
-		prerequisite = exec('make', ['-f', 'Makefile.release'], path.dirname(lzz));
+		prerequisite = exec('make', makeopts, path.dirname(lzz));
 	}
 
 	var gypArgs = debug ? ['rebuild', '--debug'] : ['rebuild'];

--- a/index.js
+++ b/index.js
@@ -28,6 +28,10 @@ module.exports = function (args, moduleDir, debug) {
 
 	var prerequisite = Promise.resolve();
 	if (buildNewLzz) {
+		var makeopts = ['-f', 'Makefile.release'];
+		if (process.env.JOBS) {
+			makeopts.push("-j" + process.env.JOBS);
+		}
 		prerequisite = exec('make', ['-f', 'Makefile.release'], path.dirname(lzz));
 	}
 


### PR DESCRIPTION
a few npm packages allow passing -j to make through the JOBS environment variable, so i added it to lzz-gyp. this speeds up building better-sqlite3 on a raspberry pi 2 by a fair bit.

the only thing i can think of that this might cause trouble with is bsd make