### PR TITLE
Resolve the file to an absolute path when executing to fix Windows

### DIFF
--- a/lib/exec.js
+++ b/lib/exec.js
@@ -1,4 +1,5 @@
 'use strict';
+var which = require('which');
 var spawn = require('child_process').spawn;
 var spawnOptions = {
 	encoding: 'utf8',
@@ -10,6 +11,11 @@ module.exports = function (file, args, cwd) {
 	return new Promise(function (resolve, reject) {
 		console.log('==>', 'cwd:', cwd);
 		console.log('==>', [file].concat(args).join(' '));
+
+        // Resolve the file to an absolute path to make sure it works
+        // on windows. Otherwise if you run a command with quotes, the
+        // shell resolves it to the wrong directory.
+        file = which.sync(file);
 
 		var child = spawn('"' + file + '"', args, Object.assign({cwd: cwd}, spawnOptions));
 		child.on('exit', function (code) {

--- a/package.json
+++ b/package.json
@@ -22,5 +22,8 @@
   "bugs": {
     "url": "https://github.com/JoshuaWise/lzz-gyp/issues"
   },
-  "homepage": "https://github.com/JoshuaWise/lzz-gyp#readme"
+  "homepage": "https://github.com/JoshuaWise/lzz-gyp#readme",
+  "dependencies": {
+    "which": "^1.3.0"
+  }
 }


### PR DESCRIPTION
I just tried to port my Electron app to Windows and ran into an annoying bug. better-sqlite3 simply wouldn't compile, showing this error:

```
Error: Cannot find module 'C:\Users\User\actual\packages\loot-core\node_modules\node-gyp\bin\node-gyp.js'
```

Things I noticed:

* The `integer` dep, another native module, compiled just fine
* Happens with both npm and yarn, both installed fresh and in the proper way
* I'm using yarn workspaces so things are split up into separate packages. I don't have `node-gyp` globally (node doesn't come with it by default anymore), but my top-level repo does have it because I use `electron-builder` which specifies it as a dependency. So it exists at `C:\Users\User\actual\node_modules\node-gyp`
* For some reason, it's still trying to look for it inside of the `loot-core` package

After digging around, I saw that better-sqlite3 uses LZZ which is compiled with the `lzz-gyp` project (another one of yours). `integer` does not use that, so it's probably something with that.

`lzz-gyp` internally does `exec("node-gyp")`, so it's got to be something with that. Some more console logging, and I noticed that it *does* properly invoke `node-gyp.CMD` inside the top-level repo. The contents of that file is:

```
@IF EXIST "%~dp0\node.exe" (
  "%~dp0\node.exe"  "%~dp0\..\node-gyp\bin\node-gyp.js" %*
) ELSE (
  @SETLOCAL
  @SET PATHEXT=%PATHEXT:;.JS;=;%
  node  "%~dp0\..\node-gyp\bin\node-gyp.js" %*
)
```

I don't know anything about windows scripting, but research shows that `%~dp0` is supposed to point the absolute path that the script exists in (same as `dirname $0` in bash). So this is trying to invoke `node-gyp.js` the exists around the same location as the above script.

It *is* invoking that script correctly, but that script somehow is trying to execute a `node-gyp.js` with the wrong path. But it *does* work it I manually run `node-gyp rebuild` in PowerShell, so it has something to do with the `exec` inside lzz-gyp.

Finally, after searching for "%~dp0 changing" I found this golden SO answer: https://stackoverflow.com/questions/12141482/in-batch-file-dp0-changes-on-changing-directory?utm_medium=organic&utm_source=google_rich_qa&utm_campaign=google_rich_qa

Evidently, for whatever reason, if you exec a file as a subprocess in Windows **and quote the file** it messes up the `%~dp0` variable. Instead of being set to the directory containing the script, it's set as the current working directory!

That's exactly what I saw, so I tried it without quotes and **it worked**! However, now we have the problem of running files with spaces in the name.

The only real solution I can think of is to use the `which` library to eagerly resolve the script to an absolute location. If you pass an absolute location with quotes to `exec`, `%~dp0` properly points to the right location.

This PR fixes building better-sqlite3 for me on Windows. And your comment in here (https://github.com/JoshuaWise/better-sqlite3/issues/127#issuecomment-386751295) makes total sense - I think it would have **happened** to work if I had installed node-gyp alongside `better-sqlite3` inside of the `loot-core` package. But that's just covering up the bug. This fix should permanently fix a lot of Windows problems.